### PR TITLE
Fix pyright standard mode type errors and add CI type checking

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,5 +29,8 @@ jobs:
         env:
           VCPKG_ROOT: /home/runner/vcpkg
 
+      - name: Type check
+        run: uv run pyright
+
       - name: Run tests
         run: uv run pytest tests/

--- a/src/lensboy/_internal/privacy.py
+++ b/src/lensboy/_internal/privacy.py
@@ -66,7 +66,7 @@ def privatize_images(
         contour = outline_px.astype(np.int32).reshape(-1, 1, 2)
 
         mask = np.zeros(image.shape[:2], dtype=np.uint8)
-        cv2.fillPoly(mask, [contour], 255)
+        cv2.fillPoly(mask, [contour], (255,))
 
         privatized = image.copy()
         privatized[mask == 0] = 0

--- a/src/lensboy/analysis/plots.py
+++ b/src/lensboy/analysis/plots.py
@@ -1404,11 +1404,11 @@ def plot_undistortion(
     grid_mask = np.zeros((H_in, W_in), dtype=np.uint8)
     for x0 in x_lines:
         cv2.line(
-            grid_mask, (int(x0), 0), (int(x0), H_in - 1), 255, thickness=line_thickness
+            grid_mask, (int(x0), 0), (int(x0), H_in - 1), (255,), thickness=line_thickness
         )
     for y0 in y_lines:
         cv2.line(
-            grid_mask, (0, int(y0)), (W_in - 1, int(y0)), 255, thickness=line_thickness
+            grid_mask, (0, int(y0)), (W_in - 1, int(y0)), (255,), thickness=line_thickness
         )
 
     grid_img = gradient_img * (grid_mask[:, :, None] > 0)

--- a/src/lensboy/calibration/calibrate.py
+++ b/src/lensboy/calibration/calibrate.py
@@ -75,7 +75,7 @@ def _mad_sigma_1d(x: np.ndarray) -> float:
     med = np.median(x)
     mad = np.median(np.abs(x - med))
     # 1.4826 = 1 / Phi^{-1}(0.75)  (MAD->sigma for 1D normal)
-    return 1.4826 * mad
+    return float(1.4826 * mad)
 
 
 def _robust_sigma_xy(residuals: list[np.ndarray]) -> float:

--- a/src/lensboy/camera_models/pinhole_remapped.py
+++ b/src/lensboy/camera_models/pinhole_remapped.py
@@ -175,7 +175,11 @@ class PinholeRemapped(CameraModel):
                 f"{(self.input_image_height, self.input_image_width)}"
             )
 
-        border_scalar = (float(border_value),) if isinstance(border_value, (int, float)) else border_value
+        border_scalar = (
+            (float(border_value),)
+            if isinstance(border_value, (int, float))
+            else border_value
+        )
         return cv2.remap(
             image,
             map_x,

--- a/src/lensboy/camera_models/pinhole_remapped.py
+++ b/src/lensboy/camera_models/pinhole_remapped.py
@@ -175,13 +175,14 @@ class PinholeRemapped(CameraModel):
                 f"{(self.input_image_height, self.input_image_width)}"
             )
 
+        border_scalar = (float(border_value),) if isinstance(border_value, (int, float)) else border_value
         return cv2.remap(
             image,
             map_x,
             map_y,
             interpolation=interpolation,
             borderMode=border_mode,
-            borderValue=border_value,
+            borderValue=border_scalar,
         )
 
     def normalize_points(self, pixel_coords: np.ndarray) -> np.ndarray:

--- a/src/lensboy/demo.py
+++ b/src/lensboy/demo.py
@@ -44,7 +44,7 @@ def _fill_triangle(
     local_tri = dst_tri - np.array([x0, y0], dtype=np.float32)
 
     mask = np.zeros((local_h, local_w), dtype=np.uint8)
-    cv2.fillConvexPoly(mask, np.round(local_tri).astype(np.int32), 1)
+    cv2.fillConvexPoly(mask, np.round(local_tri).astype(np.int32), (1,))
 
     yy, xx = np.nonzero(mask)
     if len(xx) == 0:
@@ -109,7 +109,7 @@ def _warp_grid_piecewise_linear(
         map_y,
         interpolation=cv2.INTER_LINEAR,
         borderMode=cv2.BORDER_CONSTANT,
-        borderValue=0,
+        borderValue=(0.0,),
     )
 
 


### PR DESCRIPTION
Thanks for the awesome library! Small PR to improve type checking for consumers.

- Fix OpenCV Scalar type mismatches by using tuples instead of bare ints for color/borderValue args (cv2.fillPoly, cv2.line, cv2.remap, etc.)
- Fix numpy floating return type in _mad_sigma_1d
- Add py.typed marker for PEP 561 compliance
- Add pyright step to test workflow