### PR TITLE
[Fix] Fix a corner case

### DIFF
--- a/src/lensboy/common_targets/charuco.py
+++ b/src/lensboy/common_targets/charuco.py
@@ -25,7 +25,7 @@ def _detect_charuco(img: np.ndarray, board: cv2.aruco.CharucoBoard) -> Frame | N
     if charuco_ids is None:
         return None
 
-    return Frame(charuco_ids.squeeze(), charuco_corners.squeeze(1))
+    return Frame(charuco_ids.squeeze(1), charuco_corners.squeeze(1))
 
 
 def extract_frames_from_charuco(


### PR DESCRIPTION
Note that:

In [1]: import numpy as np
In [2]: a = np.array([[1]])
In [3]: a.squeeze()
Out[3]: array(1) # and a.squeeze().shape == ()

This breaks in Frame `__postinit___` (`shape[0]` access)

We want:

In [4]: a.squeeze(1).shape
Out[4]: (1,)

BTW: might be nice to use LFS for the assets  

